### PR TITLE
Fix auth issuer resolution for hosted Supabase

### DIFF
--- a/tests/index.authIssuer.test.ts
+++ b/tests/index.authIssuer.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { resolveAuthIssuer } from '../src/index'
+
+describe('resolveAuthIssuer', () => {
+  it('returns Supabase issuer when running against hosted Supabase', () => {
+    const issuer = resolveAuthIssuer({
+      SUPABASE_URL: 'https://project.supabase.co',
+      SUPABASE_JWT_SECRET: 'unused',
+      DEV_SUPABASE_LOCAL: '0',
+    })
+    expect(issuer).toBe('https://project.supabase.co/auth/v1')
+  })
+
+  it('normalizes localhost issuer when DEV_SUPABASE_LOCAL=1', () => {
+    const issuer = resolveAuthIssuer({
+      SUPABASE_URL: 'http://localhost:54321',
+      DEV_SUPABASE_LOCAL: '1',
+    })
+    expect(issuer).toBe('http://127.0.0.1:54321/auth/v1')
+  })
+
+  it('skips normalization when DEV_SUPABASE_LOCAL=1 but host is remote', () => {
+    const issuer = resolveAuthIssuer({
+      SUPABASE_URL: 'https://example.supabase.co',
+      DEV_SUPABASE_LOCAL: '1',
+    })
+    expect(issuer).toBe('https://example.supabase.co/auth/v1')
+  })
+
+  it('returns undefined when SUPABASE_URL is missing or invalid', () => {
+    expect(resolveAuthIssuer({})).toBeUndefined()
+    expect(resolveAuthIssuer({ SUPABASE_URL: ':::::' })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- avoid overriding the Supabase issuer when running against hosted projects by introducing `resolveAuthIssuer`
- expose and reuse the helper inside the worker bootstrap to keep attachAuthContext wiring consistent
- add regression tests ensuring hosted, local, and invalid Supabase URL scenarios are handled correctly

## Testing
- pnpm test *(fails: build:client cannot resolve optional @tailwindplus/elements dependency in this environment)*
- pnpm vitest *(fails: Cloudflare Workers pool requires secrets that are not provided in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17d20ce548320b739fae23331d27c